### PR TITLE
automation~> perform SSM variable replacement

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2134,7 +2134,12 @@ class ZappaCLI(object):
                             xray_tracing=self.xray_tracing
                         )
 
+        # Perform environment variable replacement for both the aws_environment_variables
+        # and the injected environment_variables
         self.aws_environment_variables = self.perform_environment_variable_replacements(self.aws_environment_variables)
+        self.check_environment(self.aws_environment_variables)
+
+        self.environment_variables = self.perform_environment_variable_replacements(self.environment_variables)
         self.check_environment(self.environment_variables)
 
         for setting in CUSTOM_SETTINGS:

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2107,8 +2107,6 @@ class ZappaCLI(object):
         self.lambda_description = self.stage_config.get('lambda_description', "Zappa Deployment")
         self.environment_variables = self.stage_config.get('environment_variables', {})
         self.aws_environment_variables = self.stage_config.get('aws_environment_variables', {})
-        self.aws_environment_variables = self.perform_environment_variable_replacements(self.aws_environment_variables)
-        self.check_environment(self.environment_variables)
         self.authorizer = self.stage_config.get('authorizer', {})
         self.runtime = self.stage_config.get('runtime', get_runtime_from_python_version())
         self.aws_kms_key_arn = self.stage_config.get('aws_kms_key_arn', '')
@@ -2135,6 +2133,9 @@ class ZappaCLI(object):
                             endpoint_urls=self.stage_config.get('aws_endpoint_urls',{}),
                             xray_tracing=self.xray_tracing
                         )
+
+        self.aws_environment_variables = self.perform_environment_variable_replacements(self.aws_environment_variables)
+        self.check_environment(self.environment_variables)
 
         for setting in CUSTOM_SETTINGS:
             if setting in self.stage_config:

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -327,6 +327,7 @@ class Zappa(object):
             self.dynamodb_client = self.boto_client('dynamodb')
             self.cognito_client = self.boto_client('cognito-idp')
             self.sts_client = self.boto_client('sts')
+            self.ssm_client = self.boto_client('ssm')
 
         self.tags = tags
         self.cf_template = troposphere.Template()
@@ -2068,13 +2069,13 @@ class Zappa(object):
             description_kwargs['LambdaConfig'] = LambdaConfig
 
         # Note
-        # If you set a value for TemporaryPasswordValidityDays in PasswordPolicy , 
+        # If you set a value for TemporaryPasswordValidityDays in PasswordPolicy ,
         # that value will be used and UnusedAccountValidityDays will be deprecated for that user pool.
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.update_user_pool
         # Related: https://github.com/Miserlou/Zappa/issues/1879
         if 'TemporaryPasswordValidityDays' in description_kwargs['Policies']['PasswordPolicy']:
-            description_kwargs['AdminCreateUserConfig'].pop('UnusedAccountValidityDays', None)            
-            
+            description_kwargs['AdminCreateUserConfig'].pop('UnusedAccountValidityDays', None)
+
         result = self.cognito_client.update_user_pool(UserPoolId=user_pool, **description_kwargs)
         if result['ResponseMetadata']['HTTPStatusCode'] != 200:
             print("Cognito:  Failed to update user pool", result)


### PR DESCRIPTION
This looks up SSM values at deploy time for `environment_variables` and `aws_environment_variables` that begin with the string `ssm:`. This is a necessary precursor to making sure toes doesn't bring down AWS _when_ New Hampshire goes well. 
